### PR TITLE
Incorrect language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-documentation


### PR DESCRIPTION
Github Linguist misclassifies the 'fingerprint' project as 'HTML' due to the documentation file.